### PR TITLE
Replace frozendict (LGPL-3.0) with a stdlib hashable dict in lru_cache

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## [Unreleased]
+
+### Changed
+
+- Remove the ``frozendict`` dependency, replacing it with a stdlib-only hashable ``dict`` subclass used to build ``lru_cache`` keys. This drops the last LGPL-3.0 dependency from einx without changing caching behaviour (https://github.com/fferflo/einx/pull/35).
+
 ## [0.4.3]
 
 ### Fixed

--- a/einx/_src/util/lru_cache.py
+++ b/einx/_src/util/lru_cache.py
@@ -5,7 +5,6 @@ import inspect
 from collections import defaultdict
 import numpy as np
 from functools import partial
-import frozendict
 import types
 
 _thread_local = threading.local()
@@ -20,7 +19,7 @@ def _freeze_value(x):
     elif isinstance(x, list | tuple):
         return tuple(_freeze_value(x) for x in x)
     elif isinstance(x, dict):
-        return frozendict.frozendict({k: _freeze_value(v) for k, v in x.items()})
+        return tuple((k, _freeze_value(v)) for k, v in x.items())
     elif isinstance(x, types.SimpleNamespace):
         return _freeze_value(vars(x))
     elif isinstance(x, inspect.Parameter):

--- a/einx/_src/util/lru_cache.py
+++ b/einx/_src/util/lru_cache.py
@@ -13,13 +13,22 @@ warn_on_retrace_num = int(os.environ.get("EINX_WARN_ON_RETRACE", 0))
 max_cache_size = int(os.environ.get("EINX_CACHE_SIZE", -1))
 
 
+class _FrozenDict(dict):
+    # A hashable dict used to build lru_cache keys. It still behaves like a
+    # mapping, since the frozen value is read back via key access downstream,
+    # but is hashable. Hashing is order-independent so that two equal dicts
+    # always produce the same cache key.
+    def __hash__(self):
+        return hash(frozenset(self.items()))
+
+
 def _freeze_value(x):
     if isinstance(x, np.ndarray):
         return _freeze_value(x.tolist())
     elif isinstance(x, list | tuple):
         return tuple(_freeze_value(x) for x in x)
     elif isinstance(x, dict):
-        return tuple((k, _freeze_value(v)) for k, v in x.items())
+        return _FrozenDict((k, _freeze_value(v)) for k, v in x.items())
     elif isinstance(x, types.SimpleNamespace):
         return _freeze_value(vars(x))
     elif isinstance(x, inspect.Parameter):

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -22,7 +22,6 @@ readme = "README.md"
 dependencies = [
     "numpy",
     "sympy",
-    "frozendict",
 ]
 
 [project.optional-dependencies]


### PR DESCRIPTION
Closes #34.

## What

- Remove `frozendict` from `dependencies` in `pyproject.toml`
- Drop `import frozendict` from `einx/_src/util/lru_cache.py`
- Replace the `frozendict.frozendict(...)` branch in `_freeze_value` with a tiny stdlib `dict` subclass (`_FrozenDict`) that is hashable

## Why this works

`_freeze_value` produces hashable keys for `functools.lru_cache`. The frozen value must stay a real mapping, because downstream code reads it back via key access (e.g. `kwargs["backend"]` in `_construct_graph`) — so a plain tuple is not enough.

`_FrozenDict` subclasses `dict`, so it keeps full mapping behaviour, and defines an order-independent `__hash__` (`hash(frozenset(self.items()))`) so it can be used as an `lru_cache` key. Since equal dicts hash equally and compare equal, cache-hit behaviour is preserved.

## Why this matters

`frozendict` is released under **LGPL-3.0**. `einx` is MIT-licensed and widely used as a transitive dependency (e.g. via `x-transformers`), so the `frozendict` dep silently propagates LGPL-3.0 into downstream projects that otherwise use only permissive licenses. This change removes that last LGPL-3.0 dep with a stdlib-only replacement.

## Notes

- An earlier revision of this PR replaced the frozen dict with a plain `tuple`. That broke the test suite (`TypeError: tuple indices must be integers or slices, not str`) because the frozen value is read back as a mapping downstream. The `_FrozenDict` approach fixes this while keeping the no-`frozendict` goal.
- Added a CHANGELOG entry.
